### PR TITLE
Adding data-named-route-params attribute to automatically fill in URL

### DIFF
--- a/angular.named-routes.js
+++ b/angular.named-routes.js
@@ -69,11 +69,17 @@ angular.module("zj.namedRoutes", [])
                 link: function(scope, element, attributes){
                     var options = {};
                     var newKey;
+                    if(attributes.hasOwnProperty('namedRouteParams')){
+                        /*
+                            Parses the supplied $routeParams object to
+                            automatically fill in the route parameters.
+                        */
+                        options = eval("(" + attributes.namedRouteParams + ")");
+                    }
                     for(var key in attributes){
                         if(key.indexOf('kwarg')===0){
                             newKey = key.replace('kwarg','');
                             newKey = newKey.charAt(0).toLowerCase() + newKey.slice(1);
-                            console.log(key, newKey)
                             options[newKey] = attributes[key];
                         }
                     }


### PR DESCRIPTION
Adding `data-named-route-params` attribute to automatically fill in URL based on existing $routeParams (or any object containing the parameters)

An example would be:

_in controller_

``` javascript
$scope.routeParams = $routeParams; // or $scope.routeParams = {itemId: 1, shoeId: 5131242};
```

_and in the view_

``` html
<a data-named-url='some-route' data-named-route-params='{{routeParams}}'>Link to some/route</a>
```

Resulting in a link like `http://www.somesite.com/item/1/view/shoes/5131242`
