### PR TITLE
Updated prefix to make it compatible with angular 1.3

### DIFF
--- a/src/lib/named-routes.coffee
+++ b/src/lib/named-routes.coffee
@@ -18,7 +18,10 @@ angular.module "zj.namedRoutes", []
           #           .html5Mode(false)
           #           .hashPrefix("!");
           #
-          prefix = if not $locationProvider.html5Mode() then "#" + $locationProvider.hashPrefix() else ""
+          if type $locationProvider.html5Mode() == 'boolean'
+              prefix = if not $locationProvider.html5Mode() then "#" + $locationProvider.hashPrefix() else ""
+          else
+              prefix = if not $locationProvider.html5Mode().enabled then "#" + $locationProvider.hashPrefix() else ""
 
           type = (obj) ->
             if obj == undefined or obj == null

--- a/src/lib/named-routes.coffee
+++ b/src/lib/named-routes.coffee
@@ -18,10 +18,7 @@ angular.module "zj.namedRoutes", []
           #           .html5Mode(false)
           #           .hashPrefix("!");
           #
-          if type $locationProvider.html5Mode() == 'boolean'
-              prefix = if not $locationProvider.html5Mode() then "#" + $locationProvider.hashPrefix() else ""
-          else
-              prefix = if not $locationProvider.html5Mode().enabled then "#" + $locationProvider.hashPrefix() else ""
+          
 
           type = (obj) ->
             if obj == undefined or obj == null
@@ -36,6 +33,11 @@ angular.module "zj.namedRoutes", []
               '[object RegExp]': 'regexp'
               '[object Object]': 'object'
             classToType[Object.prototype.toString.call(obj)]
+            
+          if type $locationProvider.html5Mode() == 'boolean'
+              prefix = if not $locationProvider.html5Mode() then "#" + $locationProvider.hashPrefix() else ""
+          else
+              prefix = if not $locationProvider.html5Mode().enabled then "#" + $locationProvider.hashPrefix() else ""
 
           routeService =
             reverse: (routeName, options) ->


### PR DESCRIPTION
In angular 1.3 html5Mode is now an object so a boolean check always returns the same result, I have done a check using the provided type function to decide whether to inspect the 'enabled' property on the object (1.3) or just check the boolean (1.2)
