### PR TITLE
Handle optional parameter

### DIFF
--- a/build/lib/named-routes.js
+++ b/build/lib/named-routes.js
@@ -45,7 +45,7 @@
             },
             resolve: function(route, options) {
               var count, pattern;
-              pattern = /(\:\w+)/g;
+              pattern = /(\:\w+)(\?)?/g;
               if (route === void 0) {
                 throw new Error("Can't resolve undefined into a route");
               }

--- a/src/lib/named-routes.coffee
+++ b/src/lib/named-routes.coffee
@@ -56,7 +56,7 @@ angular.module "zj.namedRoutes", []
               return routes
 
             resolve: (route, options) ->
-              pattern = /(\:\w+)/g
+              pattern = /(\:\w+)(\?)?/g
               if route is undefined
                 throw new Error("Can't resolve undefined into a route")
 


### PR DESCRIPTION
> path can contain optional named groups with a question mark: e.g.:name?.

This PR change the pattern of argument in url to handle optional parameters as describe in [$routeProvider](https://docs.angularjs.org/api/ngRoute/provider/$routeProvider) documentation
